### PR TITLE
fix for tileLoadedHandler event

### DIFF
--- a/openseadragon-filtering.js
+++ b/openseadragon-filtering.js
@@ -82,7 +82,7 @@
             }
             var tile = event.tile;
             var image = event.image;
-            if (image !== null) {
+            if (image !== null && typeof(image) != "undefined") {
                 var canvas = window.document.createElement('canvas');
                 canvas.width = image.width;
                 canvas.height = image.height;


### PR DESCRIPTION
added a further check for 'image' variable to see if the value is not 'undefined which caused problems while zooming while filter is attached to the 'Viewer'
fixing #7 