### PR TITLE
Fix deprecation warning, Add getFilters function

### DIFF
--- a/openseadragon-filtering.js
+++ b/openseadragon-filtering.js
@@ -42,6 +42,14 @@
         }
     };
 
+    $.Viewer.prototype.getFilters = function () {
+        if (!this.filterPluginInstance) {
+            return [];
+        } else {
+            return getFilters(this.filterPluginInstance);
+        }
+    }
+
     /**
      * @class FilterPlugin
      * @param {Object} options The options
@@ -81,7 +89,7 @@
                 return;
             }
             var tile = event.tile;
-            var image = event.image;
+            var image = event.data;
             if (image !== null && image !== undefined) {
                 var canvas = window.document.createElement('canvas');
                 canvas.width = image.width;
@@ -173,6 +181,10 @@
             rendered._filterIncrement = self.filterIncrement;
         }
     };
+
+    function getFilters(instance) {
+        return instance.filters || [];
+    }
 
     function setOptions(instance, options) {
         options = options || {};


### PR DESCRIPTION
I added a couple changes.

1. `event.image` -> `event.data`. `event.image` is deprecated and fills the console with logs when accessed a lot.

2. I added a method to retrieve existing filter options, I needed this so I can add filter new filters dynamically instead of overwriting existing filters.

usage:
```
let filters = viewer.getFilters()
filters.append({ /* new filter details */})
viewer.setFilterOptions({filters: filters})
```